### PR TITLE
python-confluent-kafka v1.9.0-post1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: {{ pkgname|lower }}
-  version: {{ version }}
+  version: {{ version|replace("-post",".post") }}
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
@@ -31,10 +31,10 @@ requirements:
     - python
     - setuptools
     - pip
-    - librdkafka >={{ version }}
+    - librdkafka >={{ version|replace("-post",".post") }}
   run:
     - python
-    - librdkafka >={{ version }}
+    - librdkafka >={{ version|replace("-post",".post") }}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set pkgname = "python-confluent-kafka" %}
 {% set name = "confluent-kafka" %}
-{% set version = "1.8.2" %}
+{% set version = "1.9.0-post1" %}
 
 package:
   name: {{ pkgname|lower }}
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/confluentinc/confluent-kafka-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 1f9fdf752958394d2c6a43da9cb976924172c494fd9db807836db8adde15481f
+  sha256: a689c305da387712fc98b4c8a672efaabca622aac0446ee1037d62f9cc33c8ca
   patches:
     - 0001-Fix-setup-for-windows.patch  # [win]
 


### PR DESCRIPTION
This is the same as #55, but the Python package version number is fixed.